### PR TITLE
Add param quit?

### DIFF
--- a/vela-lib/vela/app.rkt
+++ b/vela-lib/vela/app.rkt
@@ -20,7 +20,8 @@
   #:listen-ip    [listen-ip "127.0.0.1"]
   #:static-path  [static-path #f]
   #:static-url  [static-url #f]
-  #:log-file [log-file #f])
+  #:log-file [log-file #f]
+  #:quit? [quit #t])
 
   (serve/servlet
     (λ (req)
@@ -30,7 +31,8 @@
     #:port host/port
     #:listen-ip listen-ip
     #:log-file log-file
-    #:servlet-regexp #rx""))
+    #:servlet-regexp #rx""
+    #:quit quit))
 
 (provide
   handler%


### PR DESCRIPTION
Hello! I use Vela by craete powerfull platform on Racket to create cloud services. I need set #:quit? param to app-run (with default #t value) for block "/quit" route 